### PR TITLE
Only forward text frames to callbacks

### DIFF
--- a/src/kraft_ws_util.erl
+++ b/src/kraft_ws_util.erl
@@ -79,8 +79,10 @@ websocket_init(#{conn := Conn} = State0) ->
 
 websocket_handle(pong, #{ping := #{}} = State0) ->
     {[], State0};
-websocket_handle(Frame, State0) ->
-    module(handle, [Frame], State0).
+websocket_handle({text, _} = Frame, State0) ->
+    module(handle, [Frame], State0);
+websocket_handle(_, State0) ->
+    {[], State0}.
 
 websocket_info('$kraft_ws_ping', State0) ->
     State1 = trigger_ping(State0),

--- a/src/kraft_ws_util.erl
+++ b/src/kraft_ws_util.erl
@@ -1,5 +1,7 @@
 -module(kraft_ws_util).
 
+-include_lib("kernel/include/logger.hrl").
+
 % API
 -export([setup/4]).
 -export([callbacks/2]).
@@ -81,7 +83,13 @@ websocket_handle(pong, #{ping := #{}} = State0) ->
     {[], State0};
 websocket_handle({text, _} = Frame, State0) ->
     module(handle, [Frame], State0);
-websocket_handle(_, State0) ->
+websocket_handle(Frame, State0) when
+    element(1, Frame) =:= ping;
+    element(1, Frame) =:= pong
+->
+    {[], State0};
+websocket_handle(Frame, State0) ->
+    ?LOG_WARNING("Websocket unhandled frame: ~p", [Frame]),
     {[], State0}.
 
 websocket_info('$kraft_ws_ping', State0) ->


### PR DESCRIPTION
- ignore other websocket frames like ping, {ping, Data} ...

https://trello.com/c/9DtruwOq

Test can be found here: https://github.com/stritzinger/grisp_manager/pull/53