### PR TITLE
Allow customizing HTTP headers during websocket setup

### DIFF
--- a/src/kraft.erl
+++ b/src/kraft.erl
@@ -23,7 +23,7 @@
 -export_type([conn/0]).
 
 -type status() :: non_neg_integer() | binary().
--type headers() :: #{atom() => iolist()}.
+-type headers() :: #{binary() => iolist()}.
 -type params() :: kraft_conn:params().
 -type body() :: kraft_json:body_json() | cowboy_req:resp_body().
 -type response() :: kraft_handler:response().

--- a/src/kraft_ws_jsonrpc.erl
+++ b/src/kraft_ws_jsonrpc.erl
@@ -21,7 +21,7 @@
 -optional_callbacks([handshake/3]).
 -callback handshake(kraft:conn(), kraft_conn:params(), state()) ->
     {reply, kraft:status(), kraft:headers(), kraft:body()}
-    | {ok, state()}.
+    | {ok, state()} | {ok, kraft:headers(), state()}.
 
 -callback init(kraft:conn(), state()) -> state().
 

--- a/src/kraft_ws_util.erl
+++ b/src/kraft_ws_util.erl
@@ -47,7 +47,10 @@ handshake(Req, #{handler := Handler, state := MState0} = State0) ->
             Resp = cowboy_req:reply(Code, Headers, Body, Req),
             {ok, Resp, State0};
         {ok, MState1} ->
-            {cowboy_websocket, Req, State0#{state => MState1}}
+            {cowboy_websocket, Req, State0#{state => MState1}};
+        {ok, Headers, MState1} ->
+            Req1 = cowboy_req:set_resp_headers(Headers, Req),
+            {cowboy_websocket, Req1, State0#{state => MState1}}
     end.
 
 call(info, _Args, #{callbacks := #{{info, 2} := false}} = State0) ->


### PR DESCRIPTION
One use case is the "sec-websocket-protocol" header, which is used to negotiate the messaging protocol
to be used over the websocket connection.

Certain browsers, like Chrome, break the connection if the server does not respond with the selected
protocol.